### PR TITLE
Port more of libefiboot functions

### DIFF
--- a/devel/libefiboot/files/patch-Make.defaults
+++ b/devel/libefiboot/files/patch-Make.defaults
@@ -1,4 +1,4 @@
---- Make.defaults
+--- Make.defaults.orig	2016-06-30 14:50:32 UTC
 +++ Make.defaults
 @@ -1,5 +1,5 @@
  prefix	?= /usr/
@@ -7,9 +7,12 @@
  datadir	?= $(prefix)/share/
  mandir	?= $(datadir)/man/
  includedir ?= $(prefix)/include/
-@@ -17,7 +17,7 @@ CFLAGS	?= $(OPTIMIZE) -g3
+@@ -15,9 +15,9 @@ CCLD	:= $(if $(filter undefined,$(origin CCLD)),$(CC),
+ OPTIMIZE ?= -O2
+ CFLAGS	?= $(OPTIMIZE) -g3
  CFLAGS	:= $(CFLAGS)
- LDFLAGS ?=
+-LDFLAGS ?=
++LDFLAGS ?= -g
  LDFLAGS := $(LDFLAGS)
 -AR	:= $(CROSS_COMPILE)gcc-ar
 +AR	:= $(CROSS_COMPILE)ar

--- a/devel/libefiboot/files/patch-Makefile
+++ b/devel/libefiboot/files/patch-Makefile
@@ -1,4 +1,4 @@
---- Makefile
+--- Makefile.orig	2016-06-30 14:50:32 UTC
 +++ Makefile
 @@ -4,6 +4,8 @@ include $(TOPDIR)/Make.version
  include $(TOPDIR)/Make.rules

--- a/devel/libefiboot/files/patch-gcc.specs
+++ b/devel/libefiboot/files/patch-gcc.specs
@@ -1,4 +1,4 @@
---- gcc.specs
+--- gcc.specs.orig	2016-06-30 14:50:32 UTC
 +++ gcc.specs
 @@ -2,7 +2,7 @@
  + -D_GNU_SOURCE

--- a/devel/libefiboot/files/patch-src-Makefile
+++ b/devel/libefiboot/files/patch-src-Makefile
@@ -1,4 +1,4 @@
---- src/Makefile
+--- src/Makefile.orig	2016-06-30 14:50:32 UTC
 +++ src/Makefile
 @@ -12,7 +12,8 @@ PCTARGETS=efivar.pc efiboot.pc
  TARGETS=$(LIBTARGETS) $(STATICLIBTARGETS) $(BINTARGETS) $(PCTARGETS)

--- a/devel/libefiboot/files/patch-src-creator.c
+++ b/devel/libefiboot/files/patch-src-creator.c
@@ -212,9 +212,12 @@
  static int
  __attribute__((__nonnull__ (1,2,3)))
  find_file(const char * const filepath, char **devicep, char **relpathp)
-@@ -79,19 +269,13 @@ find_file(const char * const filepath, char **devicep,
+@@ -77,21 +267,15 @@ find_file(const char * const filepath, char **devicep,
+ 		}
+ 	} while (1);
  
- 	mounts = fopen("/proc/self/mounts", "r");
+-	mounts = fopen("/proc/self/mounts", "r");
++	mounts = fopen("/compat/linux/proc/self/mounts", "r");
  	if (mounts == NULL)
 -		return rc;
 +		return -1;

--- a/devel/libefiboot/files/patch-src-creator.c
+++ b/devel/libefiboot/files/patch-src-creator.c
@@ -273,13 +273,13 @@
 -		rc = set_disk_and_part_name(&info);
 -		if (rc < 0)
 -			goto err;
-+		info.disk_name = strdup(devpath);
-+		info.disk_name = strrchr(info.disk_name, '/');
-+		if (!info.disk_name) {
++		char *node = strrchr(devpath, '/');
++		if (!node) {
 +			errno = EINVAL;
 +			return -1;
 +		}
-+		info.disk_name++;
++		node++;
++		info.disk_name = strdup(node);
  
 +		info.part_name = malloc(PATH_MAX+1);
 +		if (!strncmp (info.disk_name, "nv", 2)) {

--- a/devel/libefiboot/files/patch-src-creator.c
+++ b/devel/libefiboot/files/patch-src-creator.c
@@ -291,3 +291,12 @@
  		disk_fd = open_disk(&info,
  		    (options& EFIBOOT_OPTIONS_WRITE_SIGNATURE)?O_RDWR:O_RDONLY);
  		if (disk_fd < 0)
+@@ -323,7 +511,7 @@ err:
+ 	if (child_devpath)
+ 		free(child_devpath);
+ 	if (parent_devpath)
+-			free(parent_devpath);
++		free(parent_devpath);
+ 	if (relpath)
+ 		free(relpath);
+ 	errno = saved_errno;

--- a/devel/libefiboot/files/patch-src-disk.c
+++ b/devel/libefiboot/files/patch-src-disk.c
@@ -1,4 +1,4 @@
---- src/disk.c
+--- src/disk.c.orig	2016-06-30 14:50:32 UTC
 +++ src/disk.c
 @@ -18,7 +18,6 @@
   * <http://www.gnu.org/licenses/>.
@@ -8,7 +8,7 @@
  #include <errno.h>
  #include <fcntl.h>
  #include <inttypes.h>
-@@ -156,7 +155,8 @@ msdos_disk_get_partition_info (int fd, int write_signature,
+@@ -156,7 +155,8 @@ msdos_disk_get_partition_info (int fd, int write_signa
          } else if (num == 0) {
  		/* Whole disk */
                  *start = 0;

--- a/devel/libefiboot/files/patch-src-dp.h
+++ b/devel/libefiboot/files/patch-src-dp.h
@@ -1,4 +1,4 @@
---- src/dp.h
+--- src/dp.h.orig	2016-06-30 14:50:32 UTC
 +++ src/dp.h
 @@ -20,7 +20,6 @@
  #ifndef _EFIVAR_INTERNAL_DP_H

--- a/devel/libefiboot/files/patch-src-efiboot.pc.in
+++ b/devel/libefiboot/files/patch-src-efiboot.pc.in
@@ -1,4 +1,4 @@
---- src/efiboot.pc.in
+--- src/efiboot.pc.in.orig	2016-06-30 14:50:32 UTC
 +++ src/efiboot.pc.in
 @@ -1,11 +1,10 @@
  prefix=/usr

--- a/devel/libefiboot/files/patch-src-efivar.c
+++ b/devel/libefiboot/files/patch-src-efivar.c
@@ -1,4 +1,4 @@
---- src/efivar.c
+--- src/efivar.c.orig	2016-06-30 14:50:32 UTC
 +++ src/efivar.c
 @@ -63,7 +63,7 @@ list_all_variables(void)
  	int rc;
@@ -18,7 +18,7 @@
  		       guid.e[0], guid.e[1], guid.e[2], guid.e[3],
  		       guid.e[4], guid.e[5]);
  		printf("Name: \"%s\"\n", name);
-@@ -280,7 +280,7 @@ prepare_data(const char *filename, void **data, size_t *data_size)
+@@ -280,7 +280,7 @@ prepare_data(const char *filename, void **data, size_t
  		goto err;
  
  	buflen = statbuf.st_size;

--- a/devel/libefiboot/files/patch-src-efivar_endian.h
+++ b/devel/libefiboot/files/patch-src-efivar_endian.h
@@ -1,4 +1,4 @@
---- src/efivar_endian.h
+--- src/efivar_endian.h.orig	2016-06-30 14:50:32 UTC
 +++ src/efivar_endian.h
 @@ -20,7 +20,7 @@
  #ifndef _EFIVAR_ENDIAN_H

--- a/devel/libefiboot/files/patch-src-efivarfs.c
+++ b/devel/libefiboot/files/patch-src-efivarfs.c
@@ -1,4 +1,4 @@
---- src/efivarfs.c
+--- src/efivarfs.c.orig	2016-06-30 14:50:32 UTC
 +++ src/efivarfs.c
 @@ -20,23 +20,20 @@
  

--- a/devel/libefiboot/files/patch-src-gpt.c
+++ b/devel/libefiboot/files/patch-src-gpt.c
@@ -1,4 +1,4 @@
---- src/gpt.c
+--- src/gpt.c.orig	2016-06-30 14:50:32 UTC
 +++ src/gpt.c
 @@ -22,7 +22,6 @@
   *

--- a/devel/libefiboot/files/patch-src-guid.c
+++ b/devel/libefiboot/files/patch-src-guid.c
@@ -1,4 +1,4 @@
---- src/guid.c
+--- src/guid.c.orig	2016-06-30 14:50:32 UTC
 +++ src/guid.c
 @@ -21,6 +21,7 @@
  #include <dlfcn.h>

--- a/devel/libefiboot/files/patch-src-guid.h
+++ b/devel/libefiboot/files/patch-src-guid.h
@@ -1,4 +1,4 @@
---- src/guid.h
+--- src/guid.h.orig	2016-06-30 14:50:32 UTC
 +++ src/guid.h
 @@ -21,7 +21,6 @@
  #ifndef LIBEFIVAR_GUID_H

--- a/devel/libefiboot/files/patch-src-include-efivar-efiboot.h
+++ b/devel/libefiboot/files/patch-src-include-efivar-efiboot.h
@@ -1,4 +1,4 @@
---- src/include/efivar/efiboot.h
+--- src/include/efivar/efiboot.h.orig	2016-06-30 14:50:32 UTC
 +++ src/include/efivar/efiboot.h
 @@ -25,12 +25,13 @@
  #include <stdarg.h>

--- a/devel/libefiboot/files/patch-src-include-efivar-efivar.h
+++ b/devel/libefiboot/files/patch-src-include-efivar-efivar.h
@@ -1,4 +1,4 @@
---- src/include/efivar/efivar.h
+--- src/include/efivar/efivar.h.orig	2016-06-30 14:50:32 UTC
 +++ src/include/efivar/efivar.h
 @@ -20,15 +20,14 @@
  #ifndef EFIVAR_H

--- a/devel/libefiboot/files/patch-src-lib.c
+++ b/devel/libefiboot/files/patch-src-lib.c
@@ -1,6 +1,6 @@
---- src/lib.c
+--- src/lib.c.orig	2016-06-30 14:50:32 UTC
 +++ src/lib.c
-@@ -69,7 +69,8 @@ efi_set_variable(efi_guid_t guid, const char *name, uint8_t *data,
+@@ -69,7 +69,8 @@ efi_set_variable(efi_guid_t guid, const char *name, ui
  {
  	return ops->set_variable(guid, name, data, data_size, attributes, mode);
  }

--- a/devel/libefiboot/files/patch-src-linux.c
+++ b/devel/libefiboot/files/patch-src-linux.c
@@ -65,7 +65,7 @@
  	if (rc != 1)
  		return -1;
  	return ret;
-@@ -161,39 +153,25 @@ int
+@@ -161,39 +153,27 @@ int
  __attribute__((__visibility__ ("hidden")))
  find_parent_devpath(const char * const child, char **parent)
  {
@@ -73,6 +73,7 @@
 -	char *node;
 -	char *linkbuf;
 +	int i;
++	char *separator;
  
 -	/* strip leading /dev/ */
 -	node = strrchr(child, '/');
@@ -87,8 +88,9 @@
 -	node++;
 +	
 +	/* handle e.g. nvd0p1 */
-+	if (child[i+1] == 'p')
-+		i++;
++	separator = strrchr(child+i, 'p');
++	if (separator)
++		i = separator - child;
 +	
 +	*parent = strndup(child, i);
  
@@ -120,7 +122,7 @@
  	return 0;
  }
  
-@@ -886,16 +864,8 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
+@@ -886,16 +866,8 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
  		perror("stat");
  		return 1;
  	}
@@ -139,7 +141,7 @@
  
  	/* IDE disks can have up to 64 partitions, or 6 bits worth,
  	 * and have one bit for the disk number.
-@@ -962,7 +932,8 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
+@@ -962,7 +934,8 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
  	}
  
  	errno = ENOSYS;
@@ -149,7 +151,7 @@
  }
  
  static ssize_t
-@@ -1000,6 +971,13 @@ ssize_t
+@@ -1000,6 +973,13 @@ ssize_t
  __attribute__((__visibility__ ("hidden")))
  make_mac_path(uint8_t *buf, ssize_t size, const char * const ifname)
  {
@@ -163,7 +165,7 @@
  	struct ifreq ifr;
  	struct ethtool_drvinfo drvinfo = { 0, };
  	int fd, rc;
-@@ -1042,4 +1020,5 @@ err:
+@@ -1042,4 +1022,5 @@ err:
  	if (fd >= 0)
  		close(fd);
  	return ret;

--- a/devel/libefiboot/files/patch-src-linux.c
+++ b/devel/libefiboot/files/patch-src-linux.c
@@ -1,6 +1,6 @@
---- src/linux.c
+--- src/linux.c.orig	2016-06-30 14:50:32 UTC
 +++ src/linux.c
-@@ -23,11 +23,7 @@
+@@ -23,12 +23,9 @@
  #include <fcntl.h>
  #include <inttypes.h>
  #include <limits.h>
@@ -10,9 +10,152 @@
  #include <net/if.h>
 -#include <scsi/scsi.h>
  #include <stdio.h>
++#include <ctype.h>
  #include <sys/ioctl.h>
  #include <sys/socket.h>
-@@ -1000,6 +996,13 @@ ssize_t
+ #include <sys/types.h>
+@@ -124,34 +121,29 @@ int
+ __attribute__((__visibility__ ("hidden")))
+ get_partition_number(const char *devpath)
+ {
+-	struct stat statbuf = { 0, };
+ 	int rc;
+-	unsigned int maj, min;
+-	char *linkbuf;
+-	uint8_t *partbuf;
++	char *partnum;
++	char *separator;
+ 	int ret = -1;
+ 
+-	rc = stat(devpath, &statbuf);
+-	if (rc < 0)
++	partnum = strrchr(devpath, '/');
++	if (!partnum)
+ 		return -1;
++	partnum++;
+ 
+-	if (!S_ISBLK(statbuf.st_mode)) {
+-		errno = EINVAL;
+-		return -1;
+-	}
++        while (*partnum++ != '\0')
++                if (isdigit(*partnum))
++			break;
+ 
+-	maj = major(statbuf.st_rdev);
+-	min = minor(statbuf.st_rdev);
+-
+-	rc = sysfs_readlink(&linkbuf, "/sys/dev/block/%u:%u", maj, min);
+-	if (rc < 0)
++ 	if (*partnum == '\0')
+ 		return -1;
+-
+-	rc = read_sysfs_file(&partbuf, "/sys/dev/block/%s/partition", linkbuf);
+-	if (rc < 0)
+-		return -1;
+-
+-	rc = sscanf((char *)partbuf, "%d\n", &ret);
++	
++	/* nvme devices have a number before partnum */
++	separator = strrchr(partnum, 'p');
++	if (separator)
++		partnum = separator + 1;
++	
++	rc = sscanf(partnum, "%d\n", &ret);
+ 	if (rc != 1)
+ 		return -1;
+ 	return ret;
+@@ -163,37 +155,41 @@ find_parent_devpath(const char * const child, char **p
+ {
+ 	int ret;
+ 	char *node;
+-	char *linkbuf;
++	char *last;
++	char save;
+ 
+ 	/* strip leading /dev/ */
+ 	node = strrchr(child, '/');
+ 	if (!node)
+ 		return -1;
+ 	node++;
+-
+-	/* look up full path symlink */
+-	ret = sysfs_readlink(&linkbuf, "/sys/class/block/%s", node);
+-	if (ret < 0)
+-		return ret;
+-
+-	/* strip child */
+-	node = strrchr(linkbuf, '/');
+-	if (!node)
++	
++	/* strip partition number */
++	last = node;
++	while (*last++ != '\0') 
++		if (isdigit(*last))
++			break;
++	
++	if (*last == '\0') 
+ 		return -1;
+-	*node = '\0';
++	
++	/* nvme devices have a number before partnum */
++	/* are there any other such devices ? */
++	if (strstr(node, "nv"))
++		last++;
++	
++	/* back up original child */
++	save = *last;
+ 
+-	/* read parent */
+-	node = strrchr(linkbuf, '/');
+-	if (!node)
+-		return -1;
+-	*node = '\0';
+-	node++;
+-
+ 	/* write out new path */
++	*last = '\0';
+ 	ret = asprintf(parent, "/dev/%s", node);
++
++	/* restore original child */
++	*last = save;
++
+ 	if (ret < 0)
+ 		return ret;
+-
+ 	return 0;
+ }
+ 
+@@ -886,16 +882,8 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
+ 		perror("stat");
+ 		return 1;
+ 	}
+-	if (S_ISBLK(buf.st_mode)) {
+-		info->major = buf.st_rdev >> 8;
+-		info->minor = buf.st_rdev & 0xFF;
+-	} else if (S_ISREG(buf.st_mode)) {
+-		info->major = buf.st_dev >> 8;
+-		info->minor = buf.st_dev & 0xFF;
+-	} else {
+-		printf("Cannot stat non-block or non-regular file\n");
+-		return 1;
+-	}
++	info->major = buf.st_rdev >> 8;
++	info->minor = buf.st_rdev & 0xFF;
+ 
+ 	/* IDE disks can have up to 64 partitions, or 6 bits worth,
+ 	 * and have one bit for the disk number.
+@@ -962,7 +950,8 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
+ 	}
+ 
+ 	errno = ENOSYS;
+-	return -1;
++	// Major is 0 on BSD, but we still make use of the rest of the info
++	return 0;
+ }
+ 
+ static ssize_t
+@@ -1000,6 +989,13 @@ ssize_t
  __attribute__((__visibility__ ("hidden")))
  make_mac_path(uint8_t *buf, ssize_t size, const char * const ifname)
  {
@@ -26,7 +169,7 @@
  	struct ifreq ifr;
  	struct ethtool_drvinfo drvinfo = { 0, };
  	int fd, rc;
-@@ -1042,4 +1045,5 @@ err:
+@@ -1042,4 +1038,5 @@ err:
  	if (fd >= 0)
  		close(fd);
  	return ret;

--- a/devel/libefiboot/files/patch-src-linux.c
+++ b/devel/libefiboot/files/patch-src-linux.c
@@ -65,7 +65,7 @@
  	if (rc != 1)
  		return -1;
  	return ret;
-@@ -161,39 +153,26 @@ int
+@@ -161,39 +153,25 @@ int
  __attribute__((__visibility__ ("hidden")))
  find_parent_devpath(const char * const child, char **parent)
  {
@@ -77,7 +77,7 @@
 -	/* strip leading /dev/ */
 -	node = strrchr(child, '/');
 -	if (!node)
-+	/* strip partition number */
++	/* find the first number */
 +	for (i = 0; child[i] != '\n'; ++i)
 +		if (isdigit(child[i]))
 +			break;
@@ -86,9 +86,8 @@
  		return -1;
 -	node++;
 +	
-+	/* nvme devices have a number before partnum */
-+	/* are there any other such devices ? */
-+	if (strstr(child, "nv"))
++	/* handle e.g. nvd0p1 */
++	if (child[i+1] == 'p')
 +		i++;
 +	
 +	*parent = strndup(child, i);
@@ -121,7 +120,7 @@
  	return 0;
  }
  
-@@ -886,16 +865,8 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
+@@ -886,16 +864,8 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
  		perror("stat");
  		return 1;
  	}
@@ -140,7 +139,7 @@
  
  	/* IDE disks can have up to 64 partitions, or 6 bits worth,
  	 * and have one bit for the disk number.
-@@ -962,7 +933,8 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
+@@ -962,7 +932,8 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
  	}
  
  	errno = ENOSYS;
@@ -150,7 +149,7 @@
  }
  
  static ssize_t
-@@ -1000,6 +972,13 @@ ssize_t
+@@ -1000,6 +971,13 @@ ssize_t
  __attribute__((__visibility__ ("hidden")))
  make_mac_path(uint8_t *buf, ssize_t size, const char * const ifname)
  {
@@ -164,7 +163,7 @@
  	struct ifreq ifr;
  	struct ethtool_drvinfo drvinfo = { 0, };
  	int fd, rc;
-@@ -1042,4 +1021,5 @@ err:
+@@ -1042,4 +1020,5 @@ err:
  	if (fd >= 0)
  		close(fd);
  	return ret;

--- a/devel/libefiboot/files/patch-src-makeguids.c
+++ b/devel/libefiboot/files/patch-src-makeguids.c
@@ -1,4 +1,4 @@
---- src/makeguids.c
+--- src/makeguids.c.orig	2016-06-30 14:50:32 UTC
 +++ src/makeguids.c
 @@ -150,18 +150,18 @@ main(int argc, char *argv[])
  	fprintf(header, "#ifndef EFIVAR_GUIDS_H\n#define EFIVAR_GUIDS_H 1\n\n");

--- a/devel/libefiboot/files/patch-src-test-tester.c
+++ b/devel/libefiboot/files/patch-src-test-tester.c
@@ -1,4 +1,4 @@
---- src/test/tester.c
+--- src/test/tester.c.orig	2016-06-30 14:50:32 UTC
 +++ src/test/tester.c
 @@ -15,7 +15,6 @@
   *

--- a/devel/libefiboot/files/patch-src-util.h
+++ b/devel/libefiboot/files/patch-src-util.h
@@ -1,6 +1,6 @@
---- src/util.h
+--- src/util.h.orig	2016-06-30 14:50:32 UTC
 +++ src/util.h
-@@ -125,14 +125,34 @@ static inline int
+@@ -125,13 +125,33 @@ static inline int
  __attribute__((unused))
  get_sector_size(int filedes)
  {
@@ -17,7 +17,7 @@
 +	return 512;
 +#endif
  }
- 
++
 +#define strdupa(str)							\
 +	({								\
 +		char *_tmp = NULL;					\
@@ -31,7 +31,6 @@
 +		asprintf(&_tmp, "%.*s", (int)(len), (str));		\
 +	 	_tmp;							\
 +	})
-+
+ 
  #define asprintfa(str, fmt, args...)					\
  	({								\
- 		char *_tmp = NULL;					\

--- a/devel/libefiboot/files/patch-src-vars.c
+++ b/devel/libefiboot/files/patch-src-vars.c
@@ -1,4 +1,4 @@
---- src/vars.c
+--- src/vars.c.orig	2016-06-30 14:50:32 UTC
 +++ src/vars.c
 @@ -24,6 +24,7 @@
  #include <stdio.h>
@@ -8,7 +8,7 @@
  #include <sys/stat.h>
  #include <sys/types.h>
  #include <sys/utsname.h>
-@@ -239,7 +240,7 @@ vars_get_variable_size(efi_guid_t guid, const char *name, size_t *size)
+@@ -239,7 +240,7 @@ vars_get_variable_size(efi_guid_t guid, const char *na
  
  	char *path = NULL;
  	int rc = asprintf(&path, "%s%s-"GUID_FORMAT"/size", get_vars_path(),
@@ -17,7 +17,7 @@
  			  guid.e[0], guid.e[1], guid.e[2], guid.e[3],
  			  guid.e[4], guid.e[5]);
  	if (rc < 0)
-@@ -292,7 +293,7 @@ vars_get_variable(efi_guid_t guid, const char *name, uint8_t **data,
+@@ -292,7 +293,7 @@ vars_get_variable(efi_guid_t guid, const char *name, u
  	char *path;
  	int rc = asprintf(&path, "%s%s-" GUID_FORMAT "/raw_var",
  			  get_vars_path(),
@@ -35,7 +35,7 @@
  			  guid.e[0], guid.e[1], guid.e[2],
  			  guid.e[3], guid.e[4], guid.e[5]);
  	if (rc < 0)
-@@ -463,7 +464,7 @@ vars_chmod_variable(efi_guid_t guid, const char *name, mode_t mode)
+@@ -463,7 +464,7 @@ vars_chmod_variable(efi_guid_t guid, const char *name,
  
  	char *path;
  	int rc = asprintf(&path, "%s%s-" GUID_FORMAT, get_vars_path(),
@@ -44,7 +44,7 @@
  			  guid.e[0], guid.e[1], guid.e[2], guid.e[3],
  			  guid.e[4], guid.e[5]);
  	if (rc < 0)
-@@ -495,7 +496,7 @@ vars_set_variable(efi_guid_t guid, const char *name, uint8_t *data,
+@@ -495,7 +496,7 @@ vars_set_variable(efi_guid_t guid, const char *name, u
  
  	char *path;
  	int rc = asprintf(&path, "%s%s-" GUID_FORMAT "/data", get_vars_path(),
@@ -53,4 +53,3 @@
  			  guid.e[0], guid.e[1], guid.e[2], guid.e[3],
  			  guid.e[4], guid.e[5]);
  	if (rc < 0)
-


### PR DESCRIPTION
libefiboot relies heavily on linux `sysfs` and `procfs`. This PR adapts some of the `sysfs` dependent functions needed in fwupd for freebsd. `linprocfs` mounted at `/compat/linux/proc` is still needed for `procfs` dependent functions.

While libefiboot upstream relies on reading `sysfs` links, this PR relies on "dumb" `/dev/` path parsing.

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>